### PR TITLE
Address 6.3.1, 6.3.3, 6.3.4, 6.3.5 from the new benchmark

### DIFF
--- a/docs/jupiterone.md
+++ b/docs/jupiterone.md
@@ -265,7 +265,7 @@ NOTE: ALL OF THE FOLLOWING DOCUMENTATION IS GENERATED USING THE
 "j1-integration document" COMMAND. DO NOT EDIT BY HAND! PLEASE SEE THE DEVELOPER
 DOCUMENTATION FOR USAGE INFORMATION:
 
-https://github.com/JupiterOne/sdk/blob/main/docs/integrations/development.md
+https://github.com/JupiterOne/sdk/blob/master/docs/integrations/development.md
 ********************************************************************************
 -->
 

--- a/src/steps/sql-admin/__recordings__/fetchSQLInstances_3897836891/recording.har
+++ b/src/steps/sql-admin/__recordings__/fetchSQLInstances_3897836891/recording.har
@@ -62,10 +62,10 @@
           "url": "https://www.googleapis.com/oauth2/v4/token"
         },
         "response": {
-          "bodySize": 561,
+          "bodySize": 602,
           "content": {
             "mimeType": "application/json; charset=UTF-8",
-            "size": 561,
+            "size": 602,
             "text": "{\"access_token\":\"[REDACTED]\",\"expires_in\":9999,\"token_type\":\"Bearer\"}"
           },
           "cookies": [],
@@ -80,7 +80,7 @@
             },
             {
               "name": "date",
-              "value": "Fri, 04 Jun 2021 17:36:18 GMT"
+              "value": "Fri, 03 Sep 2021 18:31:13 GMT"
             },
             {
               "name": "server",
@@ -104,21 +104,21 @@
             },
             {
               "name": "alt-svc",
-              "value": "h3-29=\":443\"; ma=2592000,h3-T051=\":443\"; ma=2592000,h3-Q050=\":443\"; ma=2592000,h3-Q046=\":443\"; ma=2592000,h3-Q043=\":443\"; ma=2592000,quic=\":443\"; ma=2592000; v=\"46,43\""
+              "value": "h3=\":443\"; ma=2592000,h3-29=\":443\"; ma=2592000,h3-T051=\":443\"; ma=2592000,h3-Q050=\":443\"; ma=2592000,h3-Q046=\":443\"; ma=2592000,h3-Q043=\":443\"; ma=2592000,quic=\":443\"; ma=2592000; v=\"46,43\""
             },
             {
               "name": "connection",
               "value": "close"
             }
           ],
-          "headersSize": 511,
+          "headersSize": 533,
           "httpVersion": "HTTP/1.1",
           "redirectURL": "",
           "status": 200,
           "statusText": "OK"
         },
-        "startedDateTime": "2021-06-04T17:36:18.669Z",
-        "time": 242,
+        "startedDateTime": "2021-09-03T18:31:13.109Z",
+        "time": 183,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -126,7 +126,7 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 242
+          "wait": 183
         }
       },
       {
@@ -140,7 +140,7 @@
             {
               "_fromType": "array",
               "name": "x-goog-api-client",
-              "value": "gdcl/5.0.2 gl-node/14.15.4 auth/7.1.0"
+              "value": "gdcl/5.0.2 gl-node/14.15.4 auth/7.1.1"
             },
             {
               "_fromType": "array",
@@ -172,18 +172,18 @@
               "value": "cloudresourcemanager.googleapis.com"
             }
           ],
-          "headersSize": 564,
+          "headersSize": 1331,
           "httpVersion": "HTTP/1.1",
           "method": "GET",
           "queryString": [],
           "url": "https://cloudresourcemanager.googleapis.com/v3/projects/j1-gc-integration-dev-v3"
         },
         "response": {
-          "bodySize": 480,
+          "bodySize": 441,
           "content": {
             "mimeType": "application/json; charset=UTF-8",
-            "size": 480,
-            "text": "{\"name\":\"projects/167984947943\",\"parent\":\"folders/306329820365\",\"projectId\":\"j1-gc-integration-dev-v3\",\"state\":\"ACTIVE\",\"displayName\":\"j1-gc-integration-dev-v3\",\"createTime\":\"2021-05-31T15:15:56.125Z\",\"updateTime\":\"2021-05-31T15:15:58.148Z\",\"etag\":\"6nNZKrLueq5A5QHM92fcDg==\"}"
+            "size": 441,
+            "text": "{\"name\":\"projects/167984947943\",\"parent\":\"folders/306329820365\",\"projectId\":\"j1-gc-integration-dev-v3\",\"state\":\"ACTIVE\",\"displayName\":\"j1-gc-integration-dev-v3\",\"createTime\":\"2021-05-31T15:15:56.125Z\",\"updateTime\":\"2021-05-31T15:15:58.148Z\",\"etag\":\"CzUfI2XTWvMJgVGlic9LWA==\"}"
           },
           "cookies": [],
           "headers": [
@@ -197,7 +197,7 @@
             },
             {
               "name": "date",
-              "value": "Fri, 04 Jun 2021 17:36:19 GMT"
+              "value": "Fri, 03 Sep 2021 18:31:14 GMT"
             },
             {
               "name": "server",
@@ -221,21 +221,21 @@
             },
             {
               "name": "alt-svc",
-              "value": "h3-29=\":443\"; ma=2592000,h3-T051=\":443\"; ma=2592000,h3-Q050=\":443\"; ma=2592000,h3-Q046=\":443\"; ma=2592000,h3-Q043=\":443\"; ma=2592000,quic=\":443\"; ma=2592000; v=\"46,43\""
+              "value": "h3=\":443\"; ma=2592000,h3-29=\":443\"; ma=2592000,h3-T051=\":443\"; ma=2592000,h3-Q050=\":443\"; ma=2592000,h3-Q046=\":443\"; ma=2592000,h3-Q043=\":443\"; ma=2592000,quic=\":443\"; ma=2592000; v=\"46,43\""
             },
             {
               "name": "connection",
               "value": "close"
             }
           ],
-          "headersSize": 488,
+          "headersSize": 510,
           "httpVersion": "HTTP/1.1",
           "redirectURL": "",
           "status": 200,
           "statusText": "OK"
         },
-        "startedDateTime": "2021-06-04T17:36:18.926Z",
-        "time": 1048,
+        "startedDateTime": "2021-09-03T18:31:13.320Z",
+        "time": 1018,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -243,7 +243,7 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 1048
+          "wait": 1018
         }
       },
       {
@@ -301,10 +301,10 @@
           "url": "https://www.googleapis.com/oauth2/v4/token"
         },
         "response": {
-          "bodySize": 571,
+          "bodySize": 568,
           "content": {
             "mimeType": "application/json; charset=UTF-8",
-            "size": 571,
+            "size": 568,
             "text": "{\"access_token\":\"[REDACTED]\",\"expires_in\":9999,\"token_type\":\"Bearer\"}"
           },
           "cookies": [],
@@ -319,7 +319,7 @@
             },
             {
               "name": "date",
-              "value": "Fri, 04 Jun 2021 17:36:20 GMT"
+              "value": "Fri, 03 Sep 2021 18:31:14 GMT"
             },
             {
               "name": "server",
@@ -343,21 +343,21 @@
             },
             {
               "name": "alt-svc",
-              "value": "h3-29=\":443\"; ma=2592000,h3-T051=\":443\"; ma=2592000,h3-Q050=\":443\"; ma=2592000,h3-Q046=\":443\"; ma=2592000,h3-Q043=\":443\"; ma=2592000,quic=\":443\"; ma=2592000; v=\"46,43\""
+              "value": "h3=\":443\"; ma=2592000,h3-29=\":443\"; ma=2592000,h3-T051=\":443\"; ma=2592000,h3-Q050=\":443\"; ma=2592000,h3-Q046=\":443\"; ma=2592000,h3-Q043=\":443\"; ma=2592000,quic=\":443\"; ma=2592000; v=\"46,43\""
             },
             {
               "name": "connection",
               "value": "close"
             }
           ],
-          "headersSize": 511,
+          "headersSize": 533,
           "httpVersion": "HTTP/1.1",
           "redirectURL": "",
           "status": 200,
           "statusText": "OK"
         },
-        "startedDateTime": "2021-06-04T17:36:20.050Z",
-        "time": 183,
+        "startedDateTime": "2021-09-03T18:31:14.407Z",
+        "time": 150,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -365,7 +365,7 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 183
+          "wait": 150
         }
       },
       {
@@ -379,7 +379,7 @@
             {
               "_fromType": "array",
               "name": "x-goog-api-client",
-              "value": "gdcl/5.0.2 gl-node/14.15.4 auth/7.1.0"
+              "value": "gdcl/5.0.2 gl-node/14.15.4 auth/7.1.1"
             },
             {
               "_fromType": "array",
@@ -411,18 +411,18 @@
               "value": "sqladmin.googleapis.com"
             }
           ],
-          "headersSize": 559,
+          "headersSize": 1326,
           "httpVersion": "HTTP/1.1",
           "method": "GET",
           "queryString": [],
           "url": "https://sqladmin.googleapis.com/sql/v1beta4/projects/j1-gc-integration-dev-v3/instances"
         },
         "response": {
-          "bodySize": 4123,
+          "bodySize": 6330,
           "content": {
             "mimeType": "application/json; charset=UTF-8",
-            "size": 4123,
-            "text": "{\"items\":[{\"kind\":\"sql#instance\",\"state\":\"RUNNABLE\",\"databaseVersion\":\"POSTGRES_13\",\"settings\":{\"authorizedGaeApplications\":[],\"tier\":\"db-custom-4-26624\",\"kind\":\"sql#settings\",\"availabilityType\":\"ZONAL\",\"pricingPlan\":\"PER_USE\",\"replicationType\":\"SYNCHRONOUS\",\"activationPolicy\":\"ALWAYS\",\"ipConfiguration\":{\"authorizedNetworks\":[],\"ipv4Enabled\":true},\"locationPreference\":{\"zone\":\"us-central1-f\",\"kind\":\"sql#locationPreference\"},\"dataDiskType\":\"PD_SSD\",\"maintenanceWindow\":{\"kind\":\"sql#maintenanceWindow\",\"hour\":0,\"day\":0},\"backupConfiguration\":{\"startTime\":\"21:00\",\"kind\":\"sql#backupConfiguration\",\"location\":\"us\",\"backupRetentionSettings\":{\"retentionUnit\":\"COUNT\",\"retainedBackups\":7},\"enabled\":false,\"replicationLogArchivingEnabled\":false,\"pointInTimeRecoveryEnabled\":false,\"transactionLogRetentionDays\":7},\"settingsVersion\":\"1\",\"storageAutoResizeLimit\":\"0\",\"storageAutoResize\":true,\"dataDiskSizeGb\":\"10\"},\"etag\":\"fbeba6872568e35a2bf3ae908e099edf735f4feecb41b57cb659334b3e6070fe\",\"ipAddresses\":[{\"type\":\"PRIMARY\",\"ipAddress\":\"34.134.130.68\"},{\"type\":\"OUTGOING\",\"ipAddress\":\"34.121.255.142\"}],\"serverCaCert\":{\"kind\":\"sql#sslCert\",\"certSerialNumber\":\"0\",\"cert\":\"-----BEGIN CERTIFICATE-----\\nMIIDfzCCAmegAwIBAgIBADANBgkqhkiG9w0BAQsFADB3MS0wKwYDVQQuEyQzNjg5\\nZmEzYS0zYWMzLTRmMGMtOWJjMS0zNjFhODYzMjNmZDYxIzAhBgNVBAMTGkdvb2ds\\nZSBDbG91ZCBTUUwgU2VydmVyIENBMRQwEgYDVQQKEwtHb29nbGUsIEluYzELMAkG\\nA1UEBhMCVVMwHhcNMjEwNTMxMTY0NDI4WhcNMzEwNTI5MTY0NTI4WjB3MS0wKwYD\\nVQQuEyQzNjg5ZmEzYS0zYWMzLTRmMGMtOWJjMS0zNjFhODYzMjNmZDYxIzAhBgNV\\nBAMTGkdvb2dsZSBDbG91ZCBTUUwgU2VydmVyIENBMRQwEgYDVQQKEwtHb29nbGUs\\nIEluYzELMAkGA1UEBhMCVVMwggEiMA0GCSqGSIb3DQEBAQUAA4IBDwAwggEKAoIB\\nAQDaSFrVVfEDVLbxb33pxPhFw6BiSKP6/ejP32qZc5AlriBQX80Vh5JHNZGb2CLD\\nAx/pD7sFPyp4AaSz7XD+igU/Z+mE+zYxFq2h3jWzB8OtS9MWhaIU/ZqoYHLGJRMe\\naQuDQvT+2I1R8czsQNPSykwgsD74lYv21zlQVgxj8zdl22MoGN+DYgHs3e5DV2V8\\nJJ6t1K8JpWG+PP4fZWej5JdnKXPQ4SgYkH51g/37ZzqmkS8fUIraFVzuU+QyaSm4\\ncquSZvskV6cpT6sc2aXvG5Omy8rPIuA5UgzCB+JdG8QoaRpbKOfX4NS9njtVcbHJ\\n3UnhpRCYDIg8RV1pXIPFkokbAgMBAAGjFjAUMBIGA1UdEwEB/wQIMAYBAf8CAQAw\\nDQYJKoZIhvcNAQELBQADggEBADvNQYXhPBUKwA9OUOY43vbq9/lK0xBXL9H4QVgB\\nnqKPeYwQ1fgZEy5mYLydq/uYoJpgEexOvo8RnzkI9q+/qt9XuNz1wvBJcBWtCq9+\\nBGchr0u4uFHUDnAbHDIhQVffUNhzvKrkkpBvWNTWhr7jas8C+IKQmiDug2WbN8N0\\nUzn5gw3TTugaU+FqZUM4DFBUkIAXApZKppdc/5A89Mg3No6k5enhPNeT4mAdGAEi\\nwrRRXXzpBh9Oz8wBFtiw9tk0l28zx8HSfD3jwzFKst1UXcHuMwglilrpJgfw9bP/\\naCQCewmcw/urdZEKbY9HW93EGgwWF7ywAUNDEvQ3t4OqNWc=\\n-----END CERTIFICATE-----\",\"commonName\":\"C=US,O=Google\\\\, Inc,CN=Google Cloud SQL Server CA,dnQualifier=3689fa3a-3ac3-4f0c-9bc1-361a86323fd6\",\"sha1Fingerprint\":\"ecc6c499157ef07596bba110c602490ff80c5cbb\",\"instance\":\"test-instance-delete-soon\",\"createTime\":\"2021-05-31T16:44:28.715Z\",\"expirationTime\":\"2031-05-29T16:45:28.715Z\"},\"instanceType\":\"CLOUD_SQL_INSTANCE\",\"project\":\"j1-gc-integration-dev-v3\",\"serviceAccountEmailAddress\":\"p167984947943-wcfyii@gcp-sa-cloud-sql.iam.gserviceaccount.com\",\"backendType\":\"SECOND_GEN\",\"selfLink\":\"https://www.googleapis.com/sql/v1beta4/projects/j1-gc-integration-dev-v3/instances/test-instance-delete-soon\",\"connectionName\":\"j1-gc-integration-dev-v3:us-central1:test-instance-delete-soon\",\"name\":\"test-instance-delete-soon\",\"region\":\"us-central1\",\"gceZone\":\"us-central1-f\"}]}"
+            "size": 6330,
+            "text": "{\"items\":[{\"kind\":\"sql#instance\",\"state\":\"RUNNABLE\",\"databaseVersion\":\"POSTGRES_13\",\"settings\":{\"authorizedGaeApplications\":[],\"tier\":\"db-custom-4-26624\",\"kind\":\"sql#settings\",\"availabilityType\":\"REGIONAL\",\"pricingPlan\":\"PER_USE\",\"replicationType\":\"SYNCHRONOUS\",\"activationPolicy\":\"ALWAYS\",\"ipConfiguration\":{\"authorizedNetworks\":[],\"ipv4Enabled\":true},\"locationPreference\":{\"zone\":\"us-central1-f\",\"kind\":\"sql#locationPreference\"},\"databaseFlags\":[{\"name\":\"log_min_messages\",\"value\":\"debug2\"},{\"name\":\"log_min_error_statement\",\"value\":\"info\"}],\"dataDiskType\":\"PD_SSD\",\"maintenanceWindow\":{\"kind\":\"sql#maintenanceWindow\",\"hour\":0,\"day\":0},\"backupConfiguration\":{\"startTime\":\"07:00\",\"kind\":\"sql#backupConfiguration\",\"location\":\"us\",\"backupRetentionSettings\":{\"retentionUnit\":\"COUNT\",\"retainedBackups\":7},\"enabled\":true,\"replicationLogArchivingEnabled\":true,\"pointInTimeRecoveryEnabled\":true,\"transactionLogRetentionDays\":7},\"settingsVersion\":\"4\",\"storageAutoResizeLimit\":\"0\",\"storageAutoResize\":true,\"dataDiskSizeGb\":\"100\"},\"etag\":\"31690a0156080e26fb7a1295f9be13f43bf2b17e1c8056bb4817ceeeead870df\",\"failoverReplica\":{\"available\":true},\"ipAddresses\":[{\"type\":\"PRIMARY\",\"ipAddress\":\"34.133.152.231\"}],\"serverCaCert\":{\"kind\":\"sql#sslCert\",\"certSerialNumber\":\"0\",\"cert\":\"-----BEGIN CERTIFICATE-----\\nMIIDfzCCAmegAwIBAgIBADANBgkqhkiG9w0BAQsFADB3MS0wKwYDVQQuEyRkOWU5\\nYzg3ZC05MDI3LTQxYjYtOGUxZi00YmYyYTZjNjFiOWMxIzAhBgNVBAMTGkdvb2ds\\nZSBDbG91ZCBTUUwgU2VydmVyIENBMRQwEgYDVQQKEwtHb29nbGUsIEluYzELMAkG\\nA1UEBhMCVVMwHhcNMjEwOTAzMTgyNDIzWhcNMzEwOTAxMTgyNTIzWjB3MS0wKwYD\\nVQQuEyRkOWU5Yzg3ZC05MDI3LTQxYjYtOGUxZi00YmYyYTZjNjFiOWMxIzAhBgNV\\nBAMTGkdvb2dsZSBDbG91ZCBTUUwgU2VydmVyIENBMRQwEgYDVQQKEwtHb29nbGUs\\nIEluYzELMAkGA1UEBhMCVVMwggEiMA0GCSqGSIb3DQEBAQUAA4IBDwAwggEKAoIB\\nAQCheYn+jxLuLbYug9suD0lKSnKeABt9HXJriHurJtSpyOU9Pgy3IsVBeF+vE0B5\\nKUDmGqUa0te/LZbrFJDk4yHV3FVzE3VUQwyX8ojaFBR2ITYQDgOsTbOFOheNC5kT\\n3bnXM0zkGfQ1ayPLKn30z0XZa+f0MCY84S0Y5jsiGfiH9XhPZq8QmuH7y7caId9g\\nqmixZLjL6Q+ZrJbKnb3N9BTDp2yJn4ZV72//htgt/mvXSRxSxuMpPIFiDK4ICmV8\\nYCtfMzp4nL95lWGHzCsuN75kCQA3HOGHY6yRmrWxRr8OR1OyW0UvG2TrgOUTpgf4\\nJJ85i96zNjljcXmr7cmqX7L1AgMBAAGjFjAUMBIGA1UdEwEB/wQIMAYBAf8CAQAw\\nDQYJKoZIhvcNAQELBQADggEBAEmkGjP7wkzz96RtO1byMAxZixP7iSGjYq74x9BU\\n36Z+/Uao4WwjR4rwJkr5j8Ov1wz2vTDKX7m0mijV6YBblwUD/xM6LdWzLMbTVqBv\\nhQqHzP1z0Mbjaao9VnQ8nWvuezn7zSXQBMiNEIbbHyVT4Sx9IBDNOhC4vCESYr5M\\nLDY+Nwc2Qq9E4Xg/B7f7P/lWA/qlOFBimFk6r0LUUeYJWDDyjR5XhfIQbFmXP5YZ\\niEhsjfqqrceWYRrpkq2lrCfLYd06y0T30VBtsB3stgw08pbY+iHCicdkCMKoF/LU\\nc0Ub9kTBeoIy2zmrYcscjfRMsT4+usWXXX8EaFd7ffSQkiU=\\n-----END CERTIFICATE-----\",\"commonName\":\"C=US,O=Google\\\\, Inc,CN=Google Cloud SQL Server CA,dnQualifier=d9e9c87d-9027-41b6-8e1f-4bf2a6c61b9c\",\"sha1Fingerprint\":\"1015337eeaa6b3a55bd530653c395efea2c9627e\",\"instance\":\"postgres-example\",\"createTime\":\"2021-09-03T18:24:23.973Z\",\"expirationTime\":\"2031-09-01T18:25:23.973Z\"},\"instanceType\":\"CLOUD_SQL_INSTANCE\",\"project\":\"j1-gc-integration-dev-v3\",\"serviceAccountEmailAddress\":\"p167984947943-l8c4mq@gcp-sa-cloud-sql.iam.gserviceaccount.com\",\"backendType\":\"SECOND_GEN\",\"selfLink\":\"https://www.googleapis.com/sql/v1beta4/projects/j1-gc-integration-dev-v3/instances/postgres-example\",\"connectionName\":\"j1-gc-integration-dev-v3:us-central1:postgres-example\",\"name\":\"postgres-example\",\"region\":\"us-central1\",\"gceZone\":\"us-central1-f\",\"secondaryGceZone\":\"us-central1-c\",\"createTime\":\"2021-09-03T18:22:41.002Z\"},{\"kind\":\"sql#instance\",\"state\":\"RUNNABLE\",\"databaseVersion\":\"SQLSERVER_2017_STANDARD\",\"settings\":{\"authorizedGaeApplications\":[],\"tier\":\"db-custom-4-26624\",\"kind\":\"sql#settings\",\"availabilityType\":\"REGIONAL\",\"pricingPlan\":\"PER_USE\",\"replicationType\":\"SYNCHRONOUS\",\"activationPolicy\":\"ALWAYS\",\"ipConfiguration\":{\"authorizedNetworks\":[],\"ipv4Enabled\":true},\"locationPreference\":{\"zone\":\"us-central1-c\",\"kind\":\"sql#locationPreference\"},\"databaseFlags\":[{\"name\":\"external scripts enabled\",\"value\":\"on\"},{\"name\":\"user connections\",\"value\":\"25\"},{\"name\":\"remote access\",\"value\":\"on\"},{\"name\":\"3625\",\"value\":\"on\"}],\"dataDiskType\":\"PD_SSD\",\"maintenanceWindow\":{\"kind\":\"sql#maintenanceWindow\",\"hour\":0,\"day\":0},\"backupConfiguration\":{\"startTime\":\"16:00\",\"kind\":\"sql#backupConfiguration\",\"location\":\"us\",\"backupRetentionSettings\":{\"retentionUnit\":\"COUNT\",\"retainedBackups\":7},\"enabled\":true,\"transactionLogRetentionDays\":7},\"activeDirectoryConfig\":{\"kind\":\"sql#activeDirectoryConfig\"},\"collation\":\"SQL_Latin1_General_CP1_CI_AS\",\"settingsVersion\":\"3\",\"storageAutoResizeLimit\":\"0\",\"storageAutoResize\":true,\"dataDiskSizeGb\":\"100\"},\"etag\":\"288ecd7fa055525c78e3a19e8433d49645bfbf00e0878be2d2cd75642a0c37e2\",\"failoverReplica\":{\"available\":true},\"ipAddresses\":[{\"type\":\"PRIMARY\",\"ipAddress\":\"34.133.153.7\"}],\"serverCaCert\":{\"kind\":\"sql#sslCert\",\"certSerialNumber\":\"0\",\"cert\":\"-----BEGIN CERTIFICATE-----\\nMIIDfzCCAmegAwIBAgIBADANBgkqhkiG9w0BAQsFADB3MS0wKwYDVQQuEyQwZDgw\\nNjM5MC0wMWNiLTQ5NTItOTVlYy03ZTNkZTUyYjk3YzYxIzAhBgNVBAMTGkdvb2ds\\nZSBDbG91ZCBTUUwgU2VydmVyIENBMRQwEgYDVQQKEwtHb29nbGUsIEluYzELMAkG\\nA1UEBhMCVVMwHhcNMjEwOTAzMTgxNjQyWhcNMzEwOTAxMTgxNzQyWjB3MS0wKwYD\\nVQQuEyQwZDgwNjM5MC0wMWNiLTQ5NTItOTVlYy03ZTNkZTUyYjk3YzYxIzAhBgNV\\nBAMTGkdvb2dsZSBDbG91ZCBTUUwgU2VydmVyIENBMRQwEgYDVQQKEwtHb29nbGUs\\nIEluYzELMAkGA1UEBhMCVVMwggEiMA0GCSqGSIb3DQEBAQUAA4IBDwAwggEKAoIB\\nAQC45UFrtuyrcOFXTrRg3KK4q7EEJrOh/lOQNUwJbCFJPvzG2ubJ/7nfFMpV4BpF\\nQ0xn06ZPwbCr+8i05YwxD2iOyJzLknIvKNtdvWRE3Cc9MWFQfXS5BH5sTXscwlnx\\nKTa3d7WPTGXcbmhRA/2QuR0yYfafetwQLOY/tJcVZKDH8cHiXcxXZEN/vQM2MDEx\\n1NFV1rYPuvRpKO8QAu4nxXlCDGV2ST8pjsp1d9NW+w6AbTbgsob+pywajNu87iAM\\nZseGr41zx1zthGzzAHFva9XfFRLrPRVYVZ2t6FiEhnAzS7qrmpb1m/YyI6pW9yiD\\nO1HjS4HTZxCuAi/dIyQ4mWLNAgMBAAGjFjAUMBIGA1UdEwEB/wQIMAYBAf8CAQAw\\nDQYJKoZIhvcNAQELBQADggEBAGG1pBCXc/matoIvjCXBc9bnfGuCwibPM6n48zWO\\nFc+f0GdBLxdGi2zYDwdKAv54IeXtFzGd6Ec8ORJkDh6MOQ2xDaQPK2fBUvMyYonm\\nHAYJxXgGWsTQ0r7oUrV9RyVoTpx2JXW9CV9nGbip5eFUFk7CGXJh/WLIsavOFmvW\\njigt7fFMtklYA6Zx3Qv0qj7Nphzs5+sfULH++AmDrUSWOKfff25tyq9CgM83ITwz\\neqNHpE02yVzsFyRKljkOuRNZtj0VykzMiArzdmkHiYML8qg6EwRZYprvnDylKJ53\\nIKPY3MwN1c/l/gn783Nvz/R1M3jiIPug80zF8y9UE7hE7x8=\\n-----END CERTIFICATE-----\",\"commonName\":\"C=US,O=Google\\\\, Inc,CN=Google Cloud SQL Server CA,dnQualifier=0d806390-01cb-4952-95ec-7e3de52b97c6\",\"sha1Fingerprint\":\"8bb3477d36774624584fbada8d028a12f5d8fa81\",\"instance\":\"sql-server-example\",\"createTime\":\"2021-09-03T18:16:42.648Z\",\"expirationTime\":\"2031-09-01T18:17:42.648Z\"},\"instanceType\":\"CLOUD_SQL_INSTANCE\",\"project\":\"j1-gc-integration-dev-v3\",\"serviceAccountEmailAddress\":\"p167984947943-0vbwoh@gcp-sa-cloud-sql.iam.gserviceaccount.com\",\"backendType\":\"SECOND_GEN\",\"selfLink\":\"https://www.googleapis.com/sql/v1beta4/projects/j1-gc-integration-dev-v3/instances/sql-server-example\",\"connectionName\":\"j1-gc-integration-dev-v3:us-central1:sql-server-example\",\"name\":\"sql-server-example\",\"region\":\"us-central1\",\"gceZone\":\"us-central1-c\",\"secondaryGceZone\":\"us-central1-f\",\"createTime\":\"2021-09-03T18:14:35.518Z\"}]}"
           },
           "cookies": [],
           "headers": [
@@ -436,7 +436,7 @@
             },
             {
               "name": "date",
-              "value": "Fri, 04 Jun 2021 17:36:21 GMT"
+              "value": "Fri, 03 Sep 2021 18:31:16 GMT"
             },
             {
               "name": "server",
@@ -460,21 +460,21 @@
             },
             {
               "name": "alt-svc",
-              "value": "h3-29=\":443\"; ma=2592000,h3-T051=\":443\"; ma=2592000,h3-Q050=\":443\"; ma=2592000,h3-Q046=\":443\"; ma=2592000,h3-Q043=\":443\"; ma=2592000,quic=\":443\"; ma=2592000; v=\"46,43\""
+              "value": "h3=\":443\"; ma=2592000,h3-29=\":443\"; ma=2592000,h3-T051=\":443\"; ma=2592000,h3-Q050=\":443\"; ma=2592000,h3-Q046=\":443\"; ma=2592000,h3-Q043=\":443\"; ma=2592000,quic=\":443\"; ma=2592000; v=\"46,43\""
             },
             {
               "name": "connection",
               "value": "close"
             }
           ],
-          "headersSize": 488,
+          "headersSize": 510,
           "httpVersion": "HTTP/1.1",
           "redirectURL": "",
           "status": 200,
           "statusText": "OK"
         },
-        "startedDateTime": "2021-06-04T17:36:20.240Z",
-        "time": 1003,
+        "startedDateTime": "2021-09-03T18:31:14.564Z",
+        "time": 2213,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -482,7 +482,7 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 1003
+          "wait": 2213
         }
       }
     ],

--- a/src/steps/sql-admin/__snapshots__/converters.test.ts.snap
+++ b/src/steps/sql-admin/__snapshots__/converters.test.ts.snap
@@ -263,6 +263,7 @@ Object {
   "logLockWaits": undefined,
   "logMinDurationStatement": undefined,
   "logMinErrorStatement": undefined,
+  "logMinMessages": undefined,
   "logTempFiles": undefined,
   "name": "cloud-sql-postgres",
   "requireSSL": undefined,
@@ -320,6 +321,7 @@ Object {
   "logLockWaits": undefined,
   "logMinDurationStatement": undefined,
   "logMinErrorStatement": undefined,
+  "logMinMessages": undefined,
   "logTempFiles": undefined,
   "name": "cloud-sql-postgres",
   "requireSSL": undefined,
@@ -401,11 +403,15 @@ Object {
   "crossDatabaseOwnershipChaining": undefined,
   "displayName": "cloud-sql-postgres",
   "encrypted": true,
+  "externalScriptsEnabled": undefined,
   "hasPublicIP": false,
   "kmsKeyName": undefined,
   "location": "j1-gc-integration-dev-v2:europe-west3:cloud-sql-postgres",
   "name": "cloud-sql-postgres",
+  "remoteAccess": undefined,
   "requireSSL": undefined,
+  "traceFlag": undefined,
+  "userConnections": undefined,
 }
 `;
 
@@ -453,10 +459,14 @@ Object {
   "crossDatabaseOwnershipChaining": "on",
   "displayName": "cloud-sql-postgres",
   "encrypted": true,
+  "externalScriptsEnabled": undefined,
   "hasPublicIP": false,
   "kmsKeyName": undefined,
   "location": "j1-gc-integration-dev-v2:europe-west3:cloud-sql-postgres",
   "name": "cloud-sql-postgres",
+  "remoteAccess": undefined,
   "requireSSL": undefined,
+  "traceFlag": undefined,
+  "userConnections": undefined,
 }
 `;

--- a/src/steps/sql-admin/__snapshots__/index.test.ts.snap
+++ b/src/steps/sql-admin/__snapshots__/index.test.ts.snap
@@ -511,6 +511,7 @@ aCQCewmcw/urdZEKbY9HW93EGgwWF7ywAUNDEvQ3t4OqNWc=
       "logLockWaits": undefined,
       "logMinDurationStatement": undefined,
       "logMinErrorStatement": undefined,
+      "logMinMessages": undefined,
       "logTempFiles": undefined,
       "name": "test-instance-delete-soon",
       "requireSSL": undefined,
@@ -644,6 +645,7 @@ ujSQnO+eMjAzyhM6qCBwOQGtqrI6XzWUmy7fsx0pAy1qnQ8=
       "logLockWaits": undefined,
       "logMinDurationStatement": undefined,
       "logMinErrorStatement": undefined,
+      "logMinMessages": undefined,
       "logTempFiles": undefined,
       "name": "kms-example",
       "requireSSL": undefined,
@@ -726,7 +728,7 @@ Object {
           "rawData": Object {
             "createTime": "2021-05-31T15:15:56.125Z",
             "displayName": "j1-gc-integration-dev-v3",
-            "etag": "6nNZKrLueq5A5QHM92fcDg==",
+            "etag": "CzUfI2XTWvMJgVGlic9LWA==",
             "name": "projects/167984947943",
             "parent": "folders/306329820365",
             "projectId": "j1-gc-integration-dev-v3",
@@ -750,82 +752,93 @@ Object {
       "_class": Array [
         "Database",
       ],
-      "_key": "https://www.googleapis.com/sql/v1beta4/projects/j1-gc-integration-dev-v3/instances/test-instance-delete-soon",
+      "_key": "https://www.googleapis.com/sql/v1beta4/projects/j1-gc-integration-dev-v3/instances/postgres-example",
       "_rawData": Array [
         Object {
           "name": "default",
           "rawData": Object {
             "backendType": "SECOND_GEN",
-            "connectionName": "j1-gc-integration-dev-v3:us-central1:test-instance-delete-soon",
+            "connectionName": "j1-gc-integration-dev-v3:us-central1:postgres-example",
+            "createTime": "2021-09-03T18:22:41.002Z",
             "databaseVersion": "POSTGRES_13",
-            "etag": "fbeba6872568e35a2bf3ae908e099edf735f4feecb41b57cb659334b3e6070fe",
+            "etag": "31690a0156080e26fb7a1295f9be13f43bf2b17e1c8056bb4817ceeeead870df",
+            "failoverReplica": Object {
+              "available": true,
+            },
             "gceZone": "us-central1-f",
             "instanceType": "CLOUD_SQL_INSTANCE",
             "ipAddresses": Array [
               Object {
-                "ipAddress": "34.134.130.68",
+                "ipAddress": "34.133.152.231",
                 "type": "PRIMARY",
-              },
-              Object {
-                "ipAddress": "34.121.255.142",
-                "type": "OUTGOING",
               },
             ],
             "kind": "sql#instance",
-            "name": "test-instance-delete-soon",
+            "name": "postgres-example",
             "project": "j1-gc-integration-dev-v3",
             "region": "us-central1",
-            "selfLink": "https://www.googleapis.com/sql/v1beta4/projects/j1-gc-integration-dev-v3/instances/test-instance-delete-soon",
+            "secondaryGceZone": "us-central1-c",
+            "selfLink": "https://www.googleapis.com/sql/v1beta4/projects/j1-gc-integration-dev-v3/instances/postgres-example",
             "serverCaCert": Object {
               "cert": "-----BEGIN CERTIFICATE-----
-MIIDfzCCAmegAwIBAgIBADANBgkqhkiG9w0BAQsFADB3MS0wKwYDVQQuEyQzNjg5
-ZmEzYS0zYWMzLTRmMGMtOWJjMS0zNjFhODYzMjNmZDYxIzAhBgNVBAMTGkdvb2ds
+MIIDfzCCAmegAwIBAgIBADANBgkqhkiG9w0BAQsFADB3MS0wKwYDVQQuEyRkOWU5
+Yzg3ZC05MDI3LTQxYjYtOGUxZi00YmYyYTZjNjFiOWMxIzAhBgNVBAMTGkdvb2ds
 ZSBDbG91ZCBTUUwgU2VydmVyIENBMRQwEgYDVQQKEwtHb29nbGUsIEluYzELMAkG
-A1UEBhMCVVMwHhcNMjEwNTMxMTY0NDI4WhcNMzEwNTI5MTY0NTI4WjB3MS0wKwYD
-VQQuEyQzNjg5ZmEzYS0zYWMzLTRmMGMtOWJjMS0zNjFhODYzMjNmZDYxIzAhBgNV
+A1UEBhMCVVMwHhcNMjEwOTAzMTgyNDIzWhcNMzEwOTAxMTgyNTIzWjB3MS0wKwYD
+VQQuEyRkOWU5Yzg3ZC05MDI3LTQxYjYtOGUxZi00YmYyYTZjNjFiOWMxIzAhBgNV
 BAMTGkdvb2dsZSBDbG91ZCBTUUwgU2VydmVyIENBMRQwEgYDVQQKEwtHb29nbGUs
 IEluYzELMAkGA1UEBhMCVVMwggEiMA0GCSqGSIb3DQEBAQUAA4IBDwAwggEKAoIB
-AQDaSFrVVfEDVLbxb33pxPhFw6BiSKP6/ejP32qZc5AlriBQX80Vh5JHNZGb2CLD
-Ax/pD7sFPyp4AaSz7XD+igU/Z+mE+zYxFq2h3jWzB8OtS9MWhaIU/ZqoYHLGJRMe
-aQuDQvT+2I1R8czsQNPSykwgsD74lYv21zlQVgxj8zdl22MoGN+DYgHs3e5DV2V8
-JJ6t1K8JpWG+PP4fZWej5JdnKXPQ4SgYkH51g/37ZzqmkS8fUIraFVzuU+QyaSm4
-cquSZvskV6cpT6sc2aXvG5Omy8rPIuA5UgzCB+JdG8QoaRpbKOfX4NS9njtVcbHJ
-3UnhpRCYDIg8RV1pXIPFkokbAgMBAAGjFjAUMBIGA1UdEwEB/wQIMAYBAf8CAQAw
-DQYJKoZIhvcNAQELBQADggEBADvNQYXhPBUKwA9OUOY43vbq9/lK0xBXL9H4QVgB
-nqKPeYwQ1fgZEy5mYLydq/uYoJpgEexOvo8RnzkI9q+/qt9XuNz1wvBJcBWtCq9+
-BGchr0u4uFHUDnAbHDIhQVffUNhzvKrkkpBvWNTWhr7jas8C+IKQmiDug2WbN8N0
-Uzn5gw3TTugaU+FqZUM4DFBUkIAXApZKppdc/5A89Mg3No6k5enhPNeT4mAdGAEi
-wrRRXXzpBh9Oz8wBFtiw9tk0l28zx8HSfD3jwzFKst1UXcHuMwglilrpJgfw9bP/
-aCQCewmcw/urdZEKbY9HW93EGgwWF7ywAUNDEvQ3t4OqNWc=
+AQCheYn+jxLuLbYug9suD0lKSnKeABt9HXJriHurJtSpyOU9Pgy3IsVBeF+vE0B5
+KUDmGqUa0te/LZbrFJDk4yHV3FVzE3VUQwyX8ojaFBR2ITYQDgOsTbOFOheNC5kT
+3bnXM0zkGfQ1ayPLKn30z0XZa+f0MCY84S0Y5jsiGfiH9XhPZq8QmuH7y7caId9g
+qmixZLjL6Q+ZrJbKnb3N9BTDp2yJn4ZV72//htgt/mvXSRxSxuMpPIFiDK4ICmV8
+YCtfMzp4nL95lWGHzCsuN75kCQA3HOGHY6yRmrWxRr8OR1OyW0UvG2TrgOUTpgf4
+JJ85i96zNjljcXmr7cmqX7L1AgMBAAGjFjAUMBIGA1UdEwEB/wQIMAYBAf8CAQAw
+DQYJKoZIhvcNAQELBQADggEBAEmkGjP7wkzz96RtO1byMAxZixP7iSGjYq74x9BU
+36Z+/Uao4WwjR4rwJkr5j8Ov1wz2vTDKX7m0mijV6YBblwUD/xM6LdWzLMbTVqBv
+hQqHzP1z0Mbjaao9VnQ8nWvuezn7zSXQBMiNEIbbHyVT4Sx9IBDNOhC4vCESYr5M
+LDY+Nwc2Qq9E4Xg/B7f7P/lWA/qlOFBimFk6r0LUUeYJWDDyjR5XhfIQbFmXP5YZ
+iEhsjfqqrceWYRrpkq2lrCfLYd06y0T30VBtsB3stgw08pbY+iHCicdkCMKoF/LU
+c0Ub9kTBeoIy2zmrYcscjfRMsT4+usWXXX8EaFd7ffSQkiU=
 -----END CERTIFICATE-----",
               "certSerialNumber": "0",
-              "commonName": "C=US,O=Google\\\\, Inc,CN=Google Cloud SQL Server CA,dnQualifier=3689fa3a-3ac3-4f0c-9bc1-361a86323fd6",
-              "createTime": "2021-05-31T16:44:28.715Z",
-              "expirationTime": "2031-05-29T16:45:28.715Z",
-              "instance": "test-instance-delete-soon",
+              "commonName": "C=US,O=Google\\\\, Inc,CN=Google Cloud SQL Server CA,dnQualifier=d9e9c87d-9027-41b6-8e1f-4bf2a6c61b9c",
+              "createTime": "2021-09-03T18:24:23.973Z",
+              "expirationTime": "2031-09-01T18:25:23.973Z",
+              "instance": "postgres-example",
               "kind": "sql#sslCert",
-              "sha1Fingerprint": "ecc6c499157ef07596bba110c602490ff80c5cbb",
+              "sha1Fingerprint": "1015337eeaa6b3a55bd530653c395efea2c9627e",
             },
-            "serviceAccountEmailAddress": "p167984947943-wcfyii@gcp-sa-cloud-sql.iam.gserviceaccount.com",
+            "serviceAccountEmailAddress": "p167984947943-l8c4mq@gcp-sa-cloud-sql.iam.gserviceaccount.com",
             "settings": Object {
               "activationPolicy": "ALWAYS",
               "authorizedGaeApplications": Array [],
-              "availabilityType": "ZONAL",
+              "availabilityType": "REGIONAL",
               "backupConfiguration": Object {
                 "backupRetentionSettings": Object {
                   "retainedBackups": 7,
                   "retentionUnit": "COUNT",
                 },
-                "enabled": false,
+                "enabled": true,
                 "kind": "sql#backupConfiguration",
                 "location": "us",
-                "pointInTimeRecoveryEnabled": false,
-                "replicationLogArchivingEnabled": false,
-                "startTime": "21:00",
+                "pointInTimeRecoveryEnabled": true,
+                "replicationLogArchivingEnabled": true,
+                "startTime": "07:00",
                 "transactionLogRetentionDays": 7,
               },
-              "dataDiskSizeGb": "10",
+              "dataDiskSizeGb": "100",
               "dataDiskType": "PD_SSD",
+              "databaseFlags": Array [
+                Object {
+                  "name": "log_min_messages",
+                  "value": "debug2",
+                },
+                Object {
+                  "name": "log_min_error_statement",
+                  "value": "info",
+                },
+              ],
               "ipConfiguration": Object {
                 "authorizedNetworks": Array [],
                 "ipv4Enabled": true,
@@ -842,7 +855,7 @@ aCQCewmcw/urdZEKbY9HW93EGgwWF7ywAUNDEvQ3t4OqNWc=
               },
               "pricingPlan": "PER_USE",
               "replicationType": "SYNCHRONOUS",
-              "settingsVersion": "1",
+              "settingsVersion": "4",
               "storageAutoResize": true,
               "storageAutoResizeLimit": "0",
               "tier": "db-custom-4-26624",
@@ -853,31 +866,178 @@ aCQCewmcw/urdZEKbY9HW93EGgwWF7ywAUNDEvQ3t4OqNWc=
       ],
       "_type": "google_sql_postgres_instance",
       "authorizedNetworks": Array [],
-      "automatedBackupsEnabled": false,
-      "connectionName": "j1-gc-integration-dev-v3:us-central1:test-instance-delete-soon",
+      "automatedBackupsEnabled": true,
+      "connectionName": "j1-gc-integration-dev-v3:us-central1:postgres-example",
       "createdOn": undefined,
-      "displayName": "test-instance-delete-soon",
+      "displayName": "postgres-example",
       "encrypted": true,
       "hasPublicIP": true,
       "kmsKeyName": undefined,
-      "location": "j1-gc-integration-dev-v3:us-central1:test-instance-delete-soon",
+      "location": "j1-gc-integration-dev-v3:us-central1:postgres-example",
       "logCheckpoints": undefined,
       "logConnections": undefined,
       "logDisconnections": undefined,
       "logLockWaits": undefined,
       "logMinDurationStatement": undefined,
-      "logMinErrorStatement": undefined,
+      "logMinErrorStatement": "info",
+      "logMinMessages": "debug2",
       "logTempFiles": undefined,
-      "name": "test-instance-delete-soon",
+      "name": "postgres-example",
       "requireSSL": undefined,
+    },
+    Object {
+      "_class": Array [
+        "Database",
+      ],
+      "_key": "https://www.googleapis.com/sql/v1beta4/projects/j1-gc-integration-dev-v3/instances/sql-server-example",
+      "_rawData": Array [
+        Object {
+          "name": "default",
+          "rawData": Object {
+            "backendType": "SECOND_GEN",
+            "connectionName": "j1-gc-integration-dev-v3:us-central1:sql-server-example",
+            "createTime": "2021-09-03T18:14:35.518Z",
+            "databaseVersion": "SQLSERVER_2017_STANDARD",
+            "etag": "288ecd7fa055525c78e3a19e8433d49645bfbf00e0878be2d2cd75642a0c37e2",
+            "failoverReplica": Object {
+              "available": true,
+            },
+            "gceZone": "us-central1-c",
+            "instanceType": "CLOUD_SQL_INSTANCE",
+            "ipAddresses": Array [
+              Object {
+                "ipAddress": "34.133.153.7",
+                "type": "PRIMARY",
+              },
+            ],
+            "kind": "sql#instance",
+            "name": "sql-server-example",
+            "project": "j1-gc-integration-dev-v3",
+            "region": "us-central1",
+            "secondaryGceZone": "us-central1-f",
+            "selfLink": "https://www.googleapis.com/sql/v1beta4/projects/j1-gc-integration-dev-v3/instances/sql-server-example",
+            "serverCaCert": Object {
+              "cert": "-----BEGIN CERTIFICATE-----
+MIIDfzCCAmegAwIBAgIBADANBgkqhkiG9w0BAQsFADB3MS0wKwYDVQQuEyQwZDgw
+NjM5MC0wMWNiLTQ5NTItOTVlYy03ZTNkZTUyYjk3YzYxIzAhBgNVBAMTGkdvb2ds
+ZSBDbG91ZCBTUUwgU2VydmVyIENBMRQwEgYDVQQKEwtHb29nbGUsIEluYzELMAkG
+A1UEBhMCVVMwHhcNMjEwOTAzMTgxNjQyWhcNMzEwOTAxMTgxNzQyWjB3MS0wKwYD
+VQQuEyQwZDgwNjM5MC0wMWNiLTQ5NTItOTVlYy03ZTNkZTUyYjk3YzYxIzAhBgNV
+BAMTGkdvb2dsZSBDbG91ZCBTUUwgU2VydmVyIENBMRQwEgYDVQQKEwtHb29nbGUs
+IEluYzELMAkGA1UEBhMCVVMwggEiMA0GCSqGSIb3DQEBAQUAA4IBDwAwggEKAoIB
+AQC45UFrtuyrcOFXTrRg3KK4q7EEJrOh/lOQNUwJbCFJPvzG2ubJ/7nfFMpV4BpF
+Q0xn06ZPwbCr+8i05YwxD2iOyJzLknIvKNtdvWRE3Cc9MWFQfXS5BH5sTXscwlnx
+KTa3d7WPTGXcbmhRA/2QuR0yYfafetwQLOY/tJcVZKDH8cHiXcxXZEN/vQM2MDEx
+1NFV1rYPuvRpKO8QAu4nxXlCDGV2ST8pjsp1d9NW+w6AbTbgsob+pywajNu87iAM
+ZseGr41zx1zthGzzAHFva9XfFRLrPRVYVZ2t6FiEhnAzS7qrmpb1m/YyI6pW9yiD
+O1HjS4HTZxCuAi/dIyQ4mWLNAgMBAAGjFjAUMBIGA1UdEwEB/wQIMAYBAf8CAQAw
+DQYJKoZIhvcNAQELBQADggEBAGG1pBCXc/matoIvjCXBc9bnfGuCwibPM6n48zWO
+Fc+f0GdBLxdGi2zYDwdKAv54IeXtFzGd6Ec8ORJkDh6MOQ2xDaQPK2fBUvMyYonm
+HAYJxXgGWsTQ0r7oUrV9RyVoTpx2JXW9CV9nGbip5eFUFk7CGXJh/WLIsavOFmvW
+jigt7fFMtklYA6Zx3Qv0qj7Nphzs5+sfULH++AmDrUSWOKfff25tyq9CgM83ITwz
+eqNHpE02yVzsFyRKljkOuRNZtj0VykzMiArzdmkHiYML8qg6EwRZYprvnDylKJ53
+IKPY3MwN1c/l/gn783Nvz/R1M3jiIPug80zF8y9UE7hE7x8=
+-----END CERTIFICATE-----",
+              "certSerialNumber": "0",
+              "commonName": "C=US,O=Google\\\\, Inc,CN=Google Cloud SQL Server CA,dnQualifier=0d806390-01cb-4952-95ec-7e3de52b97c6",
+              "createTime": "2021-09-03T18:16:42.648Z",
+              "expirationTime": "2031-09-01T18:17:42.648Z",
+              "instance": "sql-server-example",
+              "kind": "sql#sslCert",
+              "sha1Fingerprint": "8bb3477d36774624584fbada8d028a12f5d8fa81",
+            },
+            "serviceAccountEmailAddress": "p167984947943-0vbwoh@gcp-sa-cloud-sql.iam.gserviceaccount.com",
+            "settings": Object {
+              "activationPolicy": "ALWAYS",
+              "activeDirectoryConfig": Object {
+                "kind": "sql#activeDirectoryConfig",
+              },
+              "authorizedGaeApplications": Array [],
+              "availabilityType": "REGIONAL",
+              "backupConfiguration": Object {
+                "backupRetentionSettings": Object {
+                  "retainedBackups": 7,
+                  "retentionUnit": "COUNT",
+                },
+                "enabled": true,
+                "kind": "sql#backupConfiguration",
+                "location": "us",
+                "startTime": "16:00",
+                "transactionLogRetentionDays": 7,
+              },
+              "collation": "SQL_Latin1_General_CP1_CI_AS",
+              "dataDiskSizeGb": "100",
+              "dataDiskType": "PD_SSD",
+              "databaseFlags": Array [
+                Object {
+                  "name": "external scripts enabled",
+                  "value": "on",
+                },
+                Object {
+                  "name": "user connections",
+                  "value": "25",
+                },
+                Object {
+                  "name": "remote access",
+                  "value": "on",
+                },
+                Object {
+                  "name": "3625",
+                  "value": "on",
+                },
+              ],
+              "ipConfiguration": Object {
+                "authorizedNetworks": Array [],
+                "ipv4Enabled": true,
+              },
+              "kind": "sql#settings",
+              "locationPreference": Object {
+                "kind": "sql#locationPreference",
+                "zone": "us-central1-c",
+              },
+              "maintenanceWindow": Object {
+                "day": 0,
+                "hour": 0,
+                "kind": "sql#maintenanceWindow",
+              },
+              "pricingPlan": "PER_USE",
+              "replicationType": "SYNCHRONOUS",
+              "settingsVersion": "3",
+              "storageAutoResize": true,
+              "storageAutoResizeLimit": "0",
+              "tier": "db-custom-4-26624",
+            },
+            "state": "RUNNABLE",
+          },
+        },
+      ],
+      "_type": "google_sql_sql_server_instance",
+      "authorizedNetworks": Array [],
+      "automatedBackupsEnabled": true,
+      "connectionName": "j1-gc-integration-dev-v3:us-central1:sql-server-example",
+      "containedDatabaseAuthentication": undefined,
+      "createdOn": undefined,
+      "crossDatabaseOwnershipChaining": undefined,
+      "displayName": "sql-server-example",
+      "encrypted": true,
+      "externalScriptsEnabled": "on",
+      "hasPublicIP": true,
+      "kmsKeyName": undefined,
+      "location": "j1-gc-integration-dev-v3:us-central1:sql-server-example",
+      "name": "sql-server-example",
+      "remoteAccess": "on",
+      "requireSSL": undefined,
+      "traceFlag": "on",
+      "userConnections": 25,
     },
   ],
   "collectedRelationships": Array [],
   "encounteredTypes": Array [
     "google_cloud_project",
     "google_sql_postgres_instance",
+    "google_sql_sql_server_instance",
   ],
-  "numCollectedEntities": 2,
+  "numCollectedEntities": 3,
   "numCollectedRelationships": 0,
 }
 `;

--- a/src/steps/sql-admin/converters.ts
+++ b/src/steps/sql-admin/converters.ts
@@ -40,7 +40,9 @@ function getPostgresSpecificBenchmarkProperties(
     logDisconnections: getFlagValue(instance, 'log_disconnections'),
     // 6.2.4 Ensure that the 'log_lock_waits' database flag for Cloud SQL PostgreSQL instance is set to 'on' (Scored)
     logLockWaits: getFlagValue(instance, 'log_lock_waits'),
-    // 6.2.5 Ensure that the 'log_min_messages' database flag for Cloud SQL PostgreSQL instance is set appropriately (Not Scored)
+    // 6.2.13 Ensure that the 'log_min_messages' database flag for Cloud SQL PostgreSQL instance is set appropriately
+    logMinMessages: getFlagValue(instance, 'log_min_messages'),
+    // 6.2.14 Ensure 'log_min_error_statement' database flag for Cloud SQL PostgreSQL instance is set to 'Error' or stricter
     logMinErrorStatement: getFlagValue(instance, 'log_min_error_statement'),
     // 6.2.6 Ensure that the 'log_temp_files' database flag for Cloud SQL PostgreSQL instance is set to '0' (on) (Scored)
     logTempFiles: getFlagValue(instance, 'log_temp_files'),
@@ -55,6 +57,8 @@ function getPostgresSpecificBenchmarkProperties(
 function getSQLServerSpecificBenchmarkProperties(
   instance: sqladmin_v1beta4.Schema$DatabaseInstance,
 ) {
+  const userConnections = getFlagValue(instance, 'user connections');
+
   return {
     // 6.3.1 Ensure that the 'cross db ownership chaining' database flag for Cloud SQL SQL Server instance is set to 'off' (Scored)
     crossDatabaseOwnershipChaining: getFlagValue(
@@ -66,6 +70,14 @@ function getSQLServerSpecificBenchmarkProperties(
       instance,
       'contained database authentication',
     ),
+    // (acc. to new benchmark) 6.3.1 Ensure 'external scripts enabled' database flag for Cloud SQL SQL Server instance is set to 'off'
+    externalScriptsEnabled: getFlagValue(instance, 'external scripts enabled'),
+    // (acc. to new benchmark) 6.3.3 Ensure 'user connections' database flag for Cloud SQL SQL Server instance is set as appropriate
+    userConnections: userConnections ? parseInt(userConnections) : undefined,
+    // (acc. to new benchmark) 6.3.5 Ensure 'remote access' database flag for Cloud SQL SQL Server instance is set to 'off'
+    remoteAccess: getFlagValue(instance, 'remote access'),
+    // (acc. to new benchmark) 6.3.6 Ensure '3625 (trace flag)' database flag for Cloud SQL SQL Server instance is set to 'off'
+    traceFlag: getFlagValue(instance, '3625'),
   };
 }
 

--- a/src/steps/sql-admin/index.test.ts
+++ b/src/steps/sql-admin/index.test.ts
@@ -1,5 +1,3 @@
-jest.setTimeout(60000);
-
 import { createMockStepExecutionContext } from '@jupiterone/integration-sdk-testing';
 import { fetchSQLAdminInstances } from '.';
 import { integrationConfig } from '../../../test/config';
@@ -108,6 +106,7 @@ describe('#fetchSQLInstances', () => {
           logConnections: { type: 'string' },
           logDisconnections: { type: 'string' },
           logLockWaits: { type: 'string' },
+          logMinMessages: { type: 'string' },
           logMinErrorStatement: { type: 'string' },
           logTempFiles: { type: 'string' },
           logMinDurationStatement: { type: 'string' },
@@ -153,6 +152,10 @@ describe('#fetchSQLInstances', () => {
           automatedBackupsEnabled: { type: 'boolean' },
           kmsKeyName: { type: 'string' },
           connectionName: { type: 'string' },
+          externalScriptsEnabled: { type: 'string' }, // should we convert this to boolean?
+          userConnections: { type: 'number' },
+          remoteAccess: { type: 'string' }, // should we convert this to boolean?
+          traceFlag: { type: 'string' },
         },
       },
     });
@@ -255,6 +258,7 @@ describe('#fetchSQLInstances encrypted', () => {
           logConnections: { type: 'string' },
           logDisconnections: { type: 'string' },
           logLockWaits: { type: 'string' },
+          logMinMessages: { type: 'string' },
           logMinErrorStatement: { type: 'string' },
           logTempFiles: { type: 'string' },
           logMinDurationStatement: { type: 'string' },
@@ -300,6 +304,10 @@ describe('#fetchSQLInstances encrypted', () => {
           automatedBackupsEnabled: { type: 'boolean' },
           kmsKeyName: { type: 'string' },
           connectionName: { type: 'string' },
+          externalScriptsEnabled: { type: 'string' },
+          userConnections: { type: 'number' },
+          remoteAccess: { type: 'string' },
+          traceFlag: { type: 'string' },
         },
       },
     });


### PR DESCRIPTION
Changelog:

- 6.3.1 Ensure 'external scripts enabled' database flag for Cloud SQL SQL Server instance is set to 'off' 
- 6.3.3 Ensure 'user connections' database flag for Cloud SQL SQL Server instance is set as appropriate
- 6.3.5 Ensure 'remote access' database flag for Cloud SQL SQL Server instance is set to 'off'

Re. 6.3.4 Ensure 'user options' database flag for Cloud SQL SQL Server instance is not configured:
I don't think we need to do anything in-code for this.